### PR TITLE
Use @storybook/theming to add custom Keyhole theme

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,6 @@
-import { addDecorator, configure } from '@storybook/react'
+import { addDecorator, configure, addParameters } from '@storybook/react'
 import { withA11y } from '@storybook/addon-a11y'
+import keyholeTheme from './keyholeTheme'
 
 import '../dist/index.css'
 
@@ -9,7 +10,13 @@ function loadStories() {
   req.keys().forEach(filename => req(filename))
 }
 
-configure(loadStories, module)
+addParameters({
+  options: {
+    theme: keyholeTheme,
+  }
+})
 
 // a11y
 addDecorator(withA11y)
+
+configure(loadStories, module)

--- a/.storybook/keyholeTheme.js
+++ b/.storybook/keyholeTheme.js
@@ -1,0 +1,8 @@
+import { create } from '@storybook/theming'
+
+export default create({
+  base: 'light', // do not remove. mandatory variable
+
+  brandTitle: 'Keyhole Storybook',
+  brandImage: 'https://cdn.keyhole.co/images/press/gallery/transparent-background-logo.png',
+})

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@storybook/addon-links": "^5.0.6",
     "@storybook/addons": "^5.0.6",
     "@storybook/react": "^5.0.6",
+    "@storybook/theming": "^5.0.6",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"


### PR DESCRIPTION
### Summary
- Installed @storybook/theming for the purpose of having a Keyhole Storybook custom theme
- Set up keyholeTheme.js as the customization home-base
- Added Keyhole logo

### Screenshots
**Before**
![default Storybook theme](https://user-images.githubusercontent.com/14142540/55834149-35ea3f00-5ae7-11e9-98de-c9992a536266.png)
**After**
![Keyhole custom URL and ](https://user-images.githubusercontent.com/14142540/55834182-48647880-5ae7-11e9-9363-d600886d79b1.png)
