### PR TITLE
Install 2 addons: storysource and info. Add page favicon.

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,3 +1,4 @@
+import '@storybook/addon-storysource/register'
 import '@storybook/addon-actions/register'
 import '@storybook/addon-links/register'
 import '@storybook/addon-a11y/register'

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,5 @@
 import { addDecorator, addParameters, configure } from '@storybook/react'
+import { withInfo } from '@storybook/addon-info'
 import { withA11y } from '@storybook/addon-a11y'
 import keyholeTheme from './keyholeTheme'
 
@@ -14,7 +15,7 @@ addParameters({
   }
 })
 
-// a11y
+addDecorator(withInfo)
 addDecorator(withA11y)
 
 configure(loadStories, module)

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,1 @@
+<link rel="icon" type="image/png" href="https://cdn.keyhole.co/img/keyhole-logo-new.png" sizes="192x192">

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -9,8 +9,14 @@ module.exports = async ({ config, mode }) => {
   // Make whatever fine-grained changes you need
   config.module.rules.push({
     test: /\.styl$/,
-    loaders: ['style-loader', 'css-loader', 'stylus-loader'],
+    loaders: [
+      'style-loader', 'css-loader', 'stylus-loader',
+    ],
     include: path.resolve(__dirname, '../'),
+  }, {
+    test: /\.stories\.jsx?$/,
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    enforce: 'pre',
   });
 
   // Return the altered config

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@storybook/addon-a11y": "^5.0.6",
     "@storybook/addon-actions": "^5.0.6",
     "@storybook/addon-links": "^5.0.6",
+    "@storybook/addon-storysource": "^5.0.6",
     "@storybook/addons": "^5.0.6",
     "@storybook/react": "^5.0.6",
     "@storybook/theming": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@storybook/addon-a11y": "^5.0.6",
     "@storybook/addon-actions": "^5.0.6",
+    "@storybook/addon-info": "^5.0.6",
     "@storybook/addon-links": "^5.0.6",
     "@storybook/addon-storysource": "^5.0.6",
     "@storybook/addons": "^5.0.6",


### PR DESCRIPTION
### Summary

- [x] Installed storysource addon. This shows up as the first tab on the addon panel and will allow us to examine the full story.js code behind each component.
- [x] Installed info addon. This is accessible through an on-page "Show Info" button, and will be primarily used to examine the full list of prop types.
- [x] Added Keyhole favicon to page

### Screenshots
**Keychain favicon**
![set favicon to Keyhole logo](https://user-images.githubusercontent.com/14142540/55897339-55887280-5b8e-11e9-9368-0d81114a1051.png)
**Info on the right and storysource tab on the left**
![image](https://user-images.githubusercontent.com/14142540/55897462-8c5e8880-5b8e-11e9-8df3-0628935be780.png)
