### PR TITLE
Install viewport addon

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,4 +1,8 @@
+// addons, sorted by order in addon panel
 import '@storybook/addon-storysource/register'
 import '@storybook/addon-actions/register'
-import '@storybook/addon-links/register'
 import '@storybook/addon-a11y/register'
+
+// addons that do not appear in addon panel
+import '@storybook/addon-links/register'
+import '@storybook/addon-viewport/register'

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -2,6 +2,7 @@ import { addDecorator, addParameters, configure } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
 import { withA11y } from '@storybook/addon-a11y'
 import keyholeTheme from './keyholeTheme'
+import keyholeViewports from './keyholeViewports'
 
 // automatically import all files ending in *.stories.js
 const req = require.context('../src', true, /\.stories\.js$/)
@@ -17,5 +18,7 @@ addParameters({
 
 addDecorator(withInfo) // info addon must sit on top of other decorators to work properly
 addDecorator(withA11y)
+
+addParameters(keyholeViewports)
 
 configure(loadStories, module)

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -13,12 +13,11 @@ function loadStories() {
 addParameters({
   options: {
     theme: keyholeTheme,
-  }
+  },
+  ...keyholeViewports
 })
 
 addDecorator(withInfo) // info addon must sit on top of other decorators to work properly
 addDecorator(withA11y)
-
-addParameters(keyholeViewports)
 
 configure(loadStories, module)

--- a/.storybook/keyholeViewports.js
+++ b/.storybook/keyholeViewports.js
@@ -1,0 +1,83 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+
+const keyholeViewports = {
+  viewport: {
+    viewports: {
+      dashboardPdfExport: {
+        name: 'Dashboard PDF export',
+        styles: {
+          width: '1500px',
+          height: '800px',
+        },
+        type: 'desktop'
+      },
+      gaDesktopOne: {
+        name: 'GA Desktop 1',
+        styles: {
+          width: '1366px',
+          height: '768px',
+        },
+        type: 'desktop'
+      },
+      gaDesktopTwo: {
+        name: 'GA Desktop 2',
+        styles: {
+          width: '1920px',
+          height: '1080px',
+        },
+        type: 'desktop'
+      },
+      gaDesktopThree: {
+        name: 'GA Desktop 3',
+        styles: {
+          width: '1440px',
+          height: '900px',
+        },
+        type: 'desktop'
+      },
+      gaDesktopFour: {
+        name: 'GA Desktop 4',
+        styles: {
+          width: '1024px',
+          height: '768px',
+        },
+        type: 'desktop'
+      },
+      gaDesktopFive: {
+        name: 'GA Desktop 5',
+        styles: {
+          width: '1280px',
+          height: '800px',
+        },
+        type: 'desktop'
+      },
+      gaMobileOne: {
+        name: 'GA Mobile 1',
+        styles: {
+          width: '360px',
+          height: '640px',
+        },
+        type: 'mobile'
+      },
+      gaMobileTwo: {
+        name: 'GA Mobile 2',
+        styles: {
+          width: '375px',
+          height: '667px',
+        },
+        type: 'mobile'
+      },
+      gaMobileThree: {
+        name: 'GA Mobile 3',
+        styles: {
+          width: '414px',
+          height: '736px',
+        },
+        type: 'mobile'
+      },
+      ...INITIAL_VIEWPORTS
+    }
+  }
+}
+
+export default keyholeViewports

--- a/package-lock.json
+++ b/package-lock.json
@@ -1078,6 +1078,28 @@
         "uuid": "3.3.2"
       }
     },
+    "@storybook/addon-info": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-5.0.6.tgz",
+      "integrity": "sha512-+jkyx4MlF/wrJ+v7ybQOpGYDL2jvu/dWiVO7mitQ6oyjQiRsmBXejuHv+NXpeVAGkzfXZBsnx0eCzCJLvpF69g==",
+      "requires": {
+        "@storybook/addons": "5.0.6",
+        "@storybook/client-logger": "5.0.6",
+        "@storybook/components": "5.0.6",
+        "@storybook/theming": "5.0.6",
+        "core-js": "2.6.5",
+        "global": "4.3.2",
+        "marksy": "6.1.0",
+        "nested-object-assign": "1.0.3",
+        "prop-types": "15.7.2",
+        "react": "16.8.6",
+        "react-addons-create-fragment": "15.6.2",
+        "react-element-to-jsx-string": "14.0.2",
+        "react-is": "16.8.6",
+        "react-lifecycles-compat": "3.0.4",
+        "util-deprecate": "1.0.2"
+      }
+    },
     "@storybook/addon-links": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-5.0.6.tgz",
@@ -1090,6 +1112,48 @@
         "global": "4.3.2",
         "prop-types": "15.7.2",
         "qs": "6.7.0"
+      }
+    },
+    "@storybook/addon-storysource": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-storysource/-/addon-storysource-5.0.6.tgz",
+      "integrity": "sha512-k6lpLV2wGlokkarK/ob0SCvzlsJQHaaiz5uaWRmLePdx+cx3ifocaTV3az0Q+96/Tl8I0Zc+Dxf9eQiuQlUSEw==",
+      "requires": {
+        "@storybook/addons": "5.0.6",
+        "@storybook/components": "5.0.6",
+        "@storybook/router": "5.0.6",
+        "@storybook/theming": "5.0.6",
+        "core-js": "2.6.5",
+        "estraverse": "4.2.0",
+        "loader-utils": "1.2.3",
+        "prettier": "1.16.4",
+        "prop-types": "15.7.2",
+        "react-syntax-highlighter": "8.1.0",
+        "regenerator-runtime": "0.12.1"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
+    "@storybook/addon-viewport": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-5.0.6.tgz",
+      "integrity": "sha512-GCxTSAvIR49753snvcSI0qXQ2JJrVBlfdRpQ+F5AsG2qhw8LJAkxX6lGKsX8VeieiaMUnowQTaVx/oSGIcchhQ==",
+      "requires": {
+        "@storybook/addons": "5.0.6",
+        "@storybook/client-logger": "5.0.6",
+        "@storybook/components": "5.0.6",
+        "@storybook/core-events": "5.0.6",
+        "@storybook/theming": "5.0.6",
+        "core-js": "2.6.5",
+        "global": "4.3.2",
+        "memoizerific": "1.11.3",
+        "prop-types": "15.7.2",
+        "util-deprecate": "1.0.2"
       }
     },
     "@storybook/addons": {
@@ -2681,6 +2745,11 @@
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
+    },
+    "babel-standalone": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-standalone/-/babel-standalone-6.26.0.tgz",
+      "integrity": "sha1-Ffs9NfLEVmlYFevx7Zb+fwFbaIY="
     },
     "babylon": {
       "version": "6.18.0",
@@ -6516,6 +6585,11 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug=="
+    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -7483,8 +7557,7 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-object": {
       "version": "1.0.1",
@@ -7529,6 +7602,11 @@
       "requires": {
         "has": "1.0.3"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -8049,6 +8127,21 @@
       "requires": {
         "prop-types": "15.7.2",
         "unquote": "1.1.1"
+      }
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+    },
+    "marksy": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/marksy/-/marksy-6.1.0.tgz",
+      "integrity": "sha512-xVAuJQxwdAljvFVqlY7CIRewn5YHGvCqeJkY1bbcTBfZV4dNDSZpHWTREb1MNu/oXYzKgg5pmTfE1DIW6M1zrA==",
+      "requires": {
+        "babel-standalone": "6.26.0",
+        "he": "1.2.0",
+        "marked": "0.3.19"
       }
     },
     "math-expression-evaluator": {
@@ -8577,6 +8670,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
+    },
+    "nested-object-assign": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/nested-object-assign/-/nested-object-assign-1.0.3.tgz",
+      "integrity": "sha512-kgq1CuvLyUcbcIuTiCA93cQ2IJFSlRwXcN+hLcb2qLJwC2qrePHGZZa7IipyWqaWF6tQjdax2pQnVxdq19Zzwg=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -10344,8 +10442,7 @@
     "prettier": {
       "version": "1.16.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
-      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
-      "dev": true
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -10677,6 +10774,16 @@
         "scheduler": "0.13.6"
       }
     },
+    "react-addons-create-fragment": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz",
+      "integrity": "sha1-o5TefCx77Na1R1uhuXrEcs58dPg=",
+      "requires": {
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
+      }
+    },
     "react-clientside-effect": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.0.tgz",
@@ -10890,6 +10997,15 @@
       "requires": {
         "classnames": "2.2.6",
         "prop-types": "15.7.2"
+      }
+    },
+    "react-element-to-jsx-string": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.0.2.tgz",
+      "integrity": "sha512-eYcPUg3FJisgAb8q3sSdce8F/xMZD/iFEjMZYnkE3b7gPi5OamGr2Hst/1pE72mzn7//dfYPXb+UqPK2xdSGsg==",
+      "requires": {
+        "is-plain-object": "2.0.4",
+        "stringify-object": "3.2.2"
       }
     },
     "react-error-overlay": {
@@ -13904,6 +14020,16 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "5.1.2"
+      }
+    },
+    "stringify-object": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@storybook/addon-info": "^5.0.6",
     "@storybook/addon-links": "^5.0.6",
     "@storybook/addon-storysource": "^5.0.6",
+    "@storybook/addon-viewport": "^5.0.6",
     "@storybook/addons": "^5.0.6",
     "@storybook/react": "^5.0.6",
     "@storybook/theming": "^5.0.6",


### PR DESCRIPTION
### Summary
**Proposed Changes**
Installed the storybook viewport addon to examine components at different screen sizes.
Added 9 custom viewports: the new dash's PDF export screen resolution (1500px wide), and the other 8 are sampled from GA (specifically, screen resolutions from Keyhole's top 5 desktop screens and top 3 mobile screens).

**Dependency added**
* @storybook/addon-viewport

### Screenshots
**Full list of viewport options**
Note: the viewport addon is not accessed via the addon panel, but via the top toolbar
![Full list of viewport options](https://user-images.githubusercontent.com/14142540/55905551-2f6bce00-5ba0-11e9-97ee-5b85a5de8705.png)

