### PR TITLE
Add more button colors

### DIFF
--- a/src/molecules/Button/button.styl
+++ b/src/molecules/Button/button.styl
@@ -127,6 +127,60 @@
     border-color: darken($white, 5%)
     color: $dark-blue
 
+.kc-button--warmGray1
+  background-color: $warm-gray-1
+  border-color: $warm-gray-1
+  color: $dark-blue
+  &:hover, &:focus
+    background-color: darken($warm-gray-1, 5%)
+    border-color: darken($warm-gray-1, 5%)
+    color: $dark-blue
+
+.kc-button--warmGray2
+  background-color: $warm-gray-2
+  border-color: $warm-gray-2
+  color: $dark-blue
+  &:hover, &:focus
+    background-color: darken($warm-gray-2, 5%)
+    border-color: darken($warm-gray-2, 5%)
+    color: $dark-blue
+
+.kc-button--lightBlue
+  background-color: $light-blue
+  border-color: $light-blue
+  color: $dark-blue
+  &:hover, &:focus
+    background-color: darken($light-blue, 5%)
+    border-color: darken($light-blue, 5%)
+    color: $dark-blue
+
+.kc-button--purple
+  background-color: $purple
+  border-color: $purple
+  color: $white
+  &:hover, &:focus
+    background-color: darken($purple, 5%)
+    border-color: darken($purple, 5%)
+    color: $white
+
+.kc-button--lightPink
+  background-color: $light-pink
+  border-color: $light-pink
+  color: $dark-blue
+  &:hover, &:focus
+    background-color: darken($light-pink, 5%)
+    border-color: darken($light-pink, 5%)
+    color: $dark-blue
+
+.kc-button--lightGreen
+  background-color: $light-green
+  border-color: $light-green
+  color: $dark-blue
+  &:hover, &:focus
+    background-color: darken($light-green, 5%)
+    border-color: darken($light-green, 5%)
+    color: $dark-blue
+
 .kc-button--outline
   background-color: $white
   border: 2px solid
@@ -148,6 +202,21 @@
   &.kc-button--white
     color: $white
     background-color: transparent
+  &.kc-button--white
+    border-color: $gray
+    color: darken($gray, 30%)
+  &.kc-button--warmGray1
+    color: $warm-gray-1
+  &.kc-button--warmGray2
+    color: $warm-gray-2
+  &.kc-button--lightBlue
+    color: $light-blue
+  &.kc-button--purple
+    color: $purple
+  &.kc-button--lightPink
+    color: $light-pink
+  &.kc-button--lightGreen
+    color: $light-green
   &:hover, &:focus
     color: $white
 

--- a/src/molecules/Button/index.js
+++ b/src/molecules/Button/index.js
@@ -15,6 +15,13 @@ export const buttonColors = [
   'orange',
   'gray',
   'white',
+  'darkBlue',
+  'warmGray1',
+  'warmGray2',
+  'lightBlue',
+  'purple',
+  'lightPink',
+  'lightGreen',
 ]
 
 export const Button = (props) => {


### PR DESCRIPTION
### Summary
This pull request adds a bunch of new button colors from the brand framework:

- `darkBlue`
- `warmGray1`
- `warmGray2`
- `lightBlue`
- `purple`
- `lightPink`
- `lightGreen`

### Screenshots
![image](https://user-images.githubusercontent.com/5639253/59202402-62175000-8b6a-11e9-8d4c-6cc3217db393.png)

